### PR TITLE
check root of heroku app for success

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,19 @@ This project is build in near 2 hours so it is still pre alpha.
 
 ##Usage
 
-add the following link https://heroku-badge.herokuapp.com/?app=heroku-badge
-and specify with the app parameter the name of your app. Than the heroku badge server
-tries to call
-https://[app].herokuapp.com/images/heroku-badge.png if this failed than the failed badge will return 
-otherwise the called badge will return
+Create an `img` with src `https://heroku-badge.herokuapp.com/?app={app-name}`. E.g.,
+
+HTML:
+
+    <img src="https://heroku-badge.herokuapp.com/?app=heroku-badge" />
+
+Markdown:
+
+    [![Heroku](https://heroku-badge.herokuapp.com/?app=heroku-badge)]
 
 
 ##Todo
 
-* no nedd to upload the heroku-badge.png into your heroku app
 * configurable heroku check url
 
 ##Copyright

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ var server = connect()
 server.use(serveStatic(__dirname+'/public'));
 server.use(function (req, res, next) {
 	var app = url.parse(req.url, true).query.app;
-	requestCl.get({url:"https://"+app+".herokuapp.com/images/heroku-badge.png",  encoding: 'binary'}, function(error, response, body) {
+	requestCl.get({url:"https://"+app+".herokuapp.com/"}, function(error, response, body) {
 		if(error || response.statusCode!=200) {
 			var errorMessage = error || response.statusCode;
 			console.log('server error image for ' + app + ' error ' + errorMessage);
@@ -19,9 +19,9 @@ server.use(function (req, res, next) {
 			
 		} else {
 			console.log('server success image for ' + app);
+			var fileStream = fs.createReadStream('public/images/heroku-badge.png');
 			res.writeHead(200, {'Content-Type': 'image/png', "Cache-Control:" : "no-cache, no-store, must-revalidate" });
-			res.contentType = 'image/png';
-	     		res.end(body, 'binary');
+        		fileStream.pipe(res);
 		}
 	});
 });


### PR DESCRIPTION
This badge is a neat idea, but there's no need to require the heroku app to serve the success badge. This badge can simply check to see if the root of the app is running, and serve the badge from the file-system.
